### PR TITLE
Fixed an issue with module Gowitness.

### DIFF
--- a/armory/included/modules/Gowitness.py
+++ b/armory/included/modules/Gowitness.py
@@ -141,8 +141,8 @@ class Module(ToolTemplate):
             os.chdir(output)
 
             Popen(cmd, shell=False).wait()
+            os.chdir(cwd)
 
-        os.chdir(cwd)
         self.IPAddress.commit()
 
     def chunks(self, chunkable, n):


### PR DESCRIPTION
In the original version it did not properly change back to the
original folder and would attempt to change into the "new folder"
from the current Gowitness output folder. Therefore, I changed it to
change back to the original folder after each iteration of the folders.
