### PR TITLE
Add a GetUrls Report

### DIFF
--- a/armory/included/reports/GetUrls.py
+++ b/armory/included/reports/GetUrls.py
@@ -1,0 +1,19 @@
+from armory.included.utilities import get_urls
+from armory.included.ReportTemplate import ReportTemplate
+
+
+class Report(ReportTemplate):
+    """
+    This report displays all of the hosts sorted by service.
+    """
+
+    markdown = ["", "# ", "- "]
+
+    name = "GetUrls"
+
+    def __init__(self, db):
+        self.db = db
+
+    def run(self, args):
+        res = []
+        self.process_output(get_urls.run(self.db), args)


### PR DESCRIPTION
Added a report which basically just calls `armory.included.utilities.get_urls.run(db)`. Useful for getting the created URLs from the services available and then running the list through tools such as [tomnomnom's anti-burl](https://github.com/tomnomnom/hacks/tree/master/anti-burl) or [my URL verify script](https://github.com/ccsplit/misc_tools/blob/master/src/check_urls.rs) written in rust which does basically the same thing.