### PR TITLE
Add a flag to add the associated IP Addresses to the DomainOwnerReport.

### DIFF
--- a/armory/included/reports/DomainOwnerReport.py
+++ b/armory/included/reports/DomainOwnerReport.py
@@ -16,6 +16,12 @@ class Report(ReportTemplate):
         self.IPAddress = IPRepository(db)
         self.CIDR = CIDRRepository(db)
 
+    def set_options(self):
+        super(Report, self).set_options()
+        self.options.add_argument(
+            "-i", "--include-ips", help="Source tool", action="store_true"
+        )
+
     def run(self, args):
         # Cidrs = self.CIDR.
         results = []
@@ -25,8 +31,12 @@ class Report(ReportTemplate):
 
             if len(d.ip_addresses) > 0:
                 owner = d.ip_addresses[0].cidr.org_name
-
-                results.append("%s,%s" % (owner, d.domain))
+                ips = ""
+                if args.include_ips:
+                    ips = "[{}]".format(
+                        ", ".join([i.ip_address for i in d.ip_addresses])
+                    )
+                results.append("{}, {} {}".format(owner, d.domain, ips))
 
         res = sorted(results)
 


### PR DESCRIPTION
For convenience when the domain => IP mapping is needed I simply added
a flag to allow you to have that information as well.

(cherry picked from commit 503b21d82fac4beec745b61f5971b4dd2a666f41)

