### PR TITLE
Fixed the invalid syntax in `get_urls` and Readme.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -27,9 +27,12 @@ Additionally, it is meant to be easily extendable. Don't see a module for your f
 
 ## Prerequisites
 
-First, set up some kind of virtual environment. I like virtualenvwrapper:
+First, you will require the MySQL db header files for `mysqlclient` which can be installed with the
+following commands on the respective hosts:
+* Kali: `sudo pt install libmariadb-dev`
+* Arch: `sudo pacman -S mariadb-libs`
 
-http://virtualenvwrapper.readthedocs.io/en/latest/install.html
+Afterwards, set up some kind of virtual environment. I like [virtualenvwrapper](https://virtualenvwrapper.readthedocs.io/en/latest/install.html).
 
 ## Actually installing
 

--- a/armory/included/utilities/get_urls.py
+++ b/armory/included/utilities/get_urls.py
@@ -20,17 +20,17 @@ def run(db, tool=None, scope_type=None):
             or not scope_type  # noqa: W503
         ):
 
-            
-
             results.append(
                 "%s://%s:%s" % (p.service_name, p.ip_address.ip_address, p.port_number)
             )
         domain_list = [d for d in p.ip_address.domains]
 
         for d in domain_list:
-            if ( scope_type == "active" and d.in_scope)  # noqa: W503
-            or ( scope_type == "passive" and d.passive_scope)  # noqa: W503
-            or not scope_type:
+            if (
+                (scope_type == "active" and d.in_scope)
+                or (scope_type == "passive" and d.passive_scope)
+                or not scope_type
+            ):
                 results.append("%s://%s:%s" % (p.service_name, d.domain, p.port_number))
 
     return sort_by_url(results)


### PR DESCRIPTION
There was an invalid syntax issue in the `armory.included.utilities.get_urls`
file. Also added documentation for the `mysqlclient` issue when attempting
to install without the MySQL development header files installed.
