### PR TITLE
apt typo in Readme.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -29,7 +29,7 @@ Additionally, it is meant to be easily extendable. Don't see a module for your f
 
 First, you will require the MySQL db header files for `mysqlclient` which can be installed with the
 following commands on the respective hosts:
-* Kali: `sudo pt install libmariadb-dev`
+* Kali: `sudo apt install libmariadb-dev`
 * Arch: `sudo pacman -S mariadb-libs`
 
 Afterwards, set up some kind of virtual environment. I like [virtualenvwrapper](https://virtualenvwrapper.readthedocs.io/en/latest/install.html).


### PR DESCRIPTION
## Proposed Changes

  - Changes typo from `pt` to `apt`
