### PR TITLE
Gowitness changed the report generate command.

### DIFF
--- a/armory/included/modules/Gowitness.py
+++ b/armory/included/modules/Gowitness.py
@@ -2,10 +2,12 @@
 
 from armory.database.repositories import IPRepository
 from ..ModuleTemplate import ToolTemplate
-from subprocess import Popen
 from ..utilities import get_urls
 import os
+import re
+import subprocess
 import tempfile
+from distutils.version import LooseVersion
 from time import time
 import sys
 
@@ -15,12 +17,13 @@ if sys.version[0] == "3":
 
 
 class Module(ToolTemplate):
-    '''
+    """
     This module uses Gowitness to take a screenshot of any discovered web servers. It can be installed from:
 
     https://github.com/sensepost/gowitness
 
-    '''
+    """
+
     name = "Gowitness"
     binary_name = "gowitness"
 
@@ -139,13 +142,21 @@ class Module(ToolTemplate):
         """
 
         cwd = os.getcwd()
+        ver_pat = re.compile("gowitness:\s?(?P<ver>\d+\.\d+\.\d+)")
+        version = subprocess.getoutput("gowitness version")
+        command_change = LooseVersion("1.0.8")
+        gen_command = ["report", "generate"]
+        m = ver_pat.match(version)
+        if m:
+            if LooseVersion(m.group("ver")) <= command_change:
+                gen_command = ["generate"]
         for cmd in cmds:
             output = cmd["output"]
 
-            cmd = [self.binary, "generate"]
+            cmd = [self.binary] + gen_command
             os.chdir(output)
 
-            Popen(cmd, shell=False).wait()
+            subprocess.Popen(cmd, shell=False).wait()
             os.chdir(cwd)
 
         self.IPAddress.commit()


### PR DESCRIPTION
With version 1.0.8 the command to generate the report was
`gowitness generate`. However, with later versions it was
changed to `gowitness report generate`. Therefore, I added a
check to obtain the version and then run the appropriate generate command.

(cherry picked from commit fd098070b74a41fa5c9f9c01105a248f8f955c99)
