### PR TITLE
Update network.py

### DIFF
--- a/armory2/armory_main/models/network.py
+++ b/armory2/armory_main/models/network.py
@@ -102,7 +102,14 @@ def pre_save_domain(sender, instance, *args, **kwargs):
         try:
             base_domain = tld.get_fld(f"http://{domain_name}")
         except Exception as e:
-            base_domain = 'local'
+            # if tld fails try to extract the basedomain out of the hostname
+            try:
+                if domain_name.count('.') == 2:
+                    base_domain = domain_name.partition('.')[2]
+                elif domain_name.count('.') == 3:
+                    base_domain = domain_name.partition('.')[2].partition('.')[2]
+            except Exception as e:
+                base_domain = 'local'
 
         bd, created = BaseDomain.objects.get_or_create(name=base_domain, defaults={"active_scope":instance.active_scope, "passive_scope":instance.passive_scope})
 
@@ -120,6 +127,8 @@ def pre_save_domain(sender, instance, *args, **kwargs):
 
 @receiver(post_save, sender=Domain)
 def post_save_domain(sender, instance, created, *args, **kwargs):
+    if "offlinedns" in instance.meta:
+        return
     if created:
         domain_name = instance.name
         ips = get_ips(domain_name)


### PR DESCRIPTION
- Added some logic to fix base domains from being added under `local` and instead under the actual local domain name, such as `test.local`. So if you have `www.test.local` it will extract `test.local`. Also for the edge cases with stuff like `www.dev.test.local` there is a second check to extract just test.local as the basedomain as well. Otherwise, if that fails it will use the old behavior of defaulting to `local`.
- Added the `offlinedns` check in domain meta data to see if DNS should be queried depending on how a domain was added. This is used by the ADIDNSDump module, but could have other use cases later