### PR TITLE
Update screenshot.py for Selenium Update

### DIFF
--- a/armory2/armory_main/included/utilities/screenshot.py
+++ b/armory2/armory_main/included/utilities/screenshot.py
@@ -259,7 +259,7 @@ def web_screenshot(url, save_path, draw_box = None, arrow = False, paddingh=10, 
             xpath = items[0]
             data['color'] = items[1]
 
-            elem = driver.find_element_by_xpath(xpath)
+            elem = driver.find_element("xpath",xpath)
             
             data['startx'] = elem.location['x'] - paddingw
             data['starty'] = elem.location['y'] - paddingh


### PR DESCRIPTION
Selenium 4.3.0 update "Deprecated find_element_by_* and find_elements_by_* are now removed (#10712)" breaks screenshot on line 262. Updating with new method.

