### PR TITLE
Update Whois.py

### DIFF
--- a/armory2/armory_main/included/modules/Whois.py
+++ b/armory2/armory_main/included/modules/Whois.py
@@ -105,7 +105,7 @@ class Module(ToolTemplate):
         for cmd in cmds:
             if cmd["cidr"]:
 
-                cidr, _ = CIDR.objects.get_or_create(name=cmd["cidr_name"])
+                cidr, _ = CIDR.objects.get_or_create(name=cmd["cidr"])
                 cidr.meta["whois"] = read_file(cmd["output"])
                 cidr.save()
                 display(cidr.meta["whois"])


### PR DESCRIPTION
Fix "cidr_name" KeyError

Fixes KeyError that arises on line 108 of Whois.py when the `-c` or `--cidr` argument is passed. `cmd["cidr_name"]` is referenced, but it should be `cmd["cidr"]`.

## Before

![2023-04-19_09-32-24](https://user-images.githubusercontent.com/16895391/233110047-fe60ca85-3fc9-4fe3-9949-ac5c076b7521.png)

## After

![2023-04-19_09-34-01](https://user-images.githubusercontent.com/16895391/233110081-c556ce39-65fe-45c1-a77b-e2f393029309.png)

## Proposed Changes

  - Change `cmd["cidr_name"]` to `cmd["cidr"]`
