### PR TITLE
Update settings.py

### DIFF
--- a/armory2/armory2/settings.py
+++ b/armory2/armory2/settings.py
@@ -185,6 +185,8 @@ if ARMORY_CONFIG.get('ARMORY_CUSTOM_WEBAPPS'):
         template_paths = [f"{url}templates" for url in glob.glob(f"{p}/*/")]
 
         TEMPLATES[0]['DIRS'] += template_paths
+        static_folders = [f"{url}static" for url in glob.glob(f"{p}/*/")]
+    STATICFILES_DIRS = static_folders
 
 
 # pdb.set_trace()


### PR DESCRIPTION
Added logic to handle the webapp module import of static files. The settings.py file needs STATICFILES_DIR with entries for each webapp static file directory. Setting STATICFILES_DIR within imported settings.py does not work for some reason but importing it along with the webapp template entries does.


  -
  -
  -
