### PR TITLE
Remove unused dependency in Gowitness.py

### DIFF
--- a/armory2/armory_main/included/modules/Gowitness.py
+++ b/armory2/armory_main/included/modules/Gowitness.py
@@ -14,7 +14,6 @@ import os
 import re
 import subprocess
 import tempfile
-from distutils.version import LooseVersion
 from time import time
 import sys
 import json
@@ -154,14 +153,6 @@ class Module(ToolTemplate):
         """
 
         cwd = os.getcwd()
-        # ver_pat = re.compile("gowitness:\s?(?P<ver>\d+\.\d+\.\d+)")
-        # version = subprocess.getoutput("gowitness version")
-        # command_change = LooseVersion("1.0.8")
-        # gen_command = ["report", "generate"]
-        # m = ver_pat.match(version)
-        # if m:
-        #     if LooseVersion(m.group("ver")) <= command_change:
-        #         gen_command = ["generate"]
 
         for cmd in cmds:
             output = cmd["output"]

--- a/armory2/armory_main/included/modules/Nmap.py
+++ b/armory2/armory_main/included/modules/Nmap.py
@@ -180,9 +180,9 @@ class Module(ToolTemplate):
     def build_cmd(self, args):
         command = ""
         
-        
-        if os.getuid() > 0:
-            command = "sudo "
+        if not "docker run" in self.binary:
+            if os.getuid() > 0:
+                command = "sudo "
         command += self.binary + " -oX {output} -iL {target} "
 
         if args.tool_args:

--- a/armory2/armory_main/included/modules/NmapTargeted.py
+++ b/armory2/armory_main/included/modules/NmapTargeted.py
@@ -95,8 +95,9 @@ class Module(ToolTemplate):
     def build_cmd(self, args):
 
         cmd = ""
-        if os.getuid() > 0:
-            cmd += 'sudo '
+        if not "docker run" in self.binary:
+            if os.getuid() > 0:
+                cmd += 'sudo '
         cmd += self.binary + " {cmd_str} -oA {output} {host} -Pn "
 
         if args.tool_args:


### PR DESCRIPTION
Gowitness module errors out due to missing `distutils` module. However, this module doesn't appear to be used, so I removed references to it and old commented out code.
